### PR TITLE
quoting the scalar

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,4 +3,4 @@ parameters:
 
 services:
     checkdomain.holiday.util:
-        class: %checkdomain.holiday.util.class%
+        class: '%checkdomain.holiday.util.class%'


### PR DESCRIPTION
Not quoting the scalar "%*%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.